### PR TITLE
Add CORSMiddleware that allows requests from all origins

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -8,12 +8,6 @@ if SQLALCHEMY_DATABASE_URL.startswith("postgres://"):
     SQLALCHEMY_DATABASE_URL = SQLALCHEMY_DATABASE_URL.replace(
         "postgres://", "postgresql://", 1)
 
-# connect_args might not be needed
-# check_same_thread was a fix for an error during testing on github
-# timeout was a fix for an error during heroku build for sqlite
-# engine = create_engine(
-#     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False, 'timeout': 15}
-# )
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from . import models
 from .database import engine
 from .routers import todo, user, authentication as auth
@@ -9,3 +10,13 @@ app = FastAPI()
 app.include_router(auth.router)
 app.include_router(todo.router)
 app.include_router(user.router)
+
+origins = ["*"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,10 +9,12 @@ from app.main import app
 from app.schemas import TodoCreate, UserCreate
 from app.crud import create_user, create_todo
 
-SQLALCHEMY_DATABASE_URL = os.environ.get(
-    "POSTGRES_URL_TEST", "sqlite:///./test_db.db")
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test_db.db"
 
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
+# check_same_thread was a fix for an error during testing on github
+# timeout was a fix for an error during heroku build for sqlite and I decided to keep it for testing
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={
+                       "check_same_thread": False, 'timeout': 15})
 
 
 def get_test_db():


### PR DESCRIPTION
Added `CORSMiddleware` in order to allow requests from different origins.  I'm currently allowing requests from all origins and all types of requests like `post`, `get`, etc.

Learn more at -> https://fastapi.tiangolo.com/tutorial/cors/